### PR TITLE
Mirror of github version_sorter PR IssueNumber 17

### DIFF
--- a/ext/version_sorter/version_sorter.c
+++ b/ext/version_sorter/version_sorter.c
@@ -239,7 +239,7 @@ rb_version_sort_1(VALUE rb_self, VALUE rb_version_array, compare_callback_t cmp)
 		rb_jump_tag(exception);
 	}
 
-	return rb_version_array;
+	return result;
 }
 
 static VALUE

--- a/ext/version_sorter/version_sorter.c
+++ b/ext/version_sorter/version_sorter.c
@@ -171,47 +171,25 @@ parse_version_number(const char *string)
 	return version;
 }
 
-static VALUE rb_cSortContext;
-
 struct sort_context {
+	VALUE rb_self;
+	VALUE rb_version_array;
+	compare_callback_t *cmp;
 	struct version_number **versions;
-	long length;
 };
 
-static void sort_context_free(void *p) {
-	struct sort_context *context = p;
-	long i;
-
-	for (i = 0; i < context->length; ++i) {
-		xfree(context->versions[i]);
-	}
-	xfree(context->versions);
-	xfree(context);
-}
-
 static VALUE
-rb_version_sort_1(VALUE rb_self, VALUE rb_version_array, compare_callback_t cmp)
+rb_version_sort_1_cb(VALUE arg)
 {
+	struct sort_context *context = (struct sort_context *)arg;
 	long length, i;
 	VALUE *rb_version_ptr;
 
-	Check_Type(rb_version_array, T_ARRAY);
-
-	length = RARRAY_LEN(rb_version_array);
-	if (!length)
-		return rb_ary_new();
-
-	struct sort_context *context;
-	context = ALLOC(struct sort_context);
-	context->length = length;
-	context->versions = xcalloc(length, sizeof(struct version_number *));
-
-	VALUE data = Data_Wrap_Struct(rb_cSortContext, NULL, sort_context_free, context);
-
+	length = RARRAY_LEN(context->rb_version_array);
 	for (i = 0; i < length; ++i) {
 		VALUE rb_version, rb_version_string;
 
-		rb_version = rb_ary_entry(rb_version_array, i);
+		rb_version = rb_ary_entry(context->rb_version_array, i);
 		if (rb_block_given_p())
 			rb_version_string = rb_yield(rb_version);
 		else
@@ -221,11 +199,44 @@ rb_version_sort_1(VALUE rb_self, VALUE rb_version_array, compare_callback_t cmp)
 		context->versions[i]->rb_version = rb_version;
 	}
 
-	qsort(context->versions, length, sizeof(struct version_number *), cmp);
-	rb_version_ptr = RARRAY_PTR(rb_version_array);
+	qsort(context->versions, length, sizeof(struct version_number *), context->cmp);
+	rb_version_ptr = RARRAY_PTR(context->rb_version_array);
 
 	for (i = 0; i < length; ++i) {
 		rb_version_ptr[i] = context->versions[i]->rb_version;
+	}
+
+	return context->rb_version_array;
+}
+
+static VALUE
+rb_version_sort_1(VALUE rb_self, VALUE rb_version_array, compare_callback_t cmp)
+{
+	long length, i;
+	int exception;
+
+	Check_Type(rb_version_array, T_ARRAY);
+
+	length = RARRAY_LEN(rb_version_array);
+	if (!length)
+		return rb_ary_new();
+
+	struct sort_context context = {
+		rb_self,
+		rb_version_array,
+		cmp,
+		xcalloc(length, sizeof(struct version_number *)),
+	};
+
+	VALUE result = rb_protect(rb_version_sort_1_cb, (VALUE)&context, &exception);
+
+	for (i = 0; i < length; ++i) {
+		xfree(context.versions[i]);
+	}
+	xfree(context.versions);
+
+	if (exception) {
+		rb_jump_tag(exception);
 	}
 
 	return rb_version_array;
@@ -277,6 +288,4 @@ void Init_version_sorter(void)
 	rb_define_module_function(rb_mVersionSorter, "sort!", rb_version_sort_bang, 1);
 	rb_define_module_function(rb_mVersionSorter, "rsort!", rb_version_sort_r_bang, 1);
 	rb_define_module_function(rb_mVersionSorter, "compare", rb_version_compare, 2);
-
-	rb_cSortContext = rb_define_class_under(rb_mVersionSorter, "SortContext", rb_cObject);
 }


### PR DESCRIPTION
Mirror of github version_sorter PR IssueNumber 17
Fixes https://github.com/github/version_sorter/issues/16.

/cc <at>philipturnbull <at>mislav — I'm not an expert on Ruby extensions. In b456869 I've stored the state in a struct tracked by the GC and just left it to the GC to cleanup. In c8307a6 I use `rb_protect` instead and clean up. Either way preferred? The latter seems cleaner.
